### PR TITLE
Improve READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # tilt-extensions
+
 DirectEmployers Extensions for Tilt
 
 ## Importing the repo
-```starlark
+
+```python
 v1alpha1.extension_repo(
     name="de-tilt",
     url="https://github.com/DirectEmployers/tilt-extensions",
@@ -15,4 +17,5 @@ v1alpha1.extension(
 ```
 
 ## Extensions
-- pip_compile_button - adds button use pip-compile on requirements in a given resource
+
+- [pip_compile_button](./pip_compile_button) - adds button use pip-compile on requirements in a given resource

--- a/pip_compile_button/README.md
+++ b/pip_compile_button/README.md
@@ -1,28 +1,29 @@
 # pip_compile_button
 
-Add a button to a resource to allow pip-tools requirements to be compiled.
+Add a button to a resource to allow [pip-tools requirements](https://pip-tools.readthedocs.io/en/latest/) to be compiled.
 
-# Usage
-After importing the repo and extension (see main readme), you can invoke the extension using `pip_compile_button` in your Tiltfile.
+## Usage
 
-```skylark
+After importing the repo and extension (see [main README](../README.md)), you can invoke the extension using `pip_compile_button` in your Tiltfile.
+
+```python
 pip_compile_button(
     # Tilt resource to attach the button to.
     "resource-name",
-    
+
     # Paths of requirements files to compile.
     requirements=[
         "requirements.in",
         "requirements-dev.in",
     ],
-    
+
     # Local Destination for compiled requirements.
     destination="./",
-    
+
     # Optional, use if different than 'deploy/resource-name'.
     exec_path="exec_path",
-    
-    # Any compatible arguments you would like to send to pip-compile. 
+
+    # Any arguments you would like to send to pip-compile.
     compile_args=["--quiet", "--cache-dir=DIRECTORY"],
 )
 ```


### PR DESCRIPTION
## Improve main README

- Use Python syntax highlighting
- Add link to pip_compile_button
- Add whitespace

## Improve pip_compile_button README

- Use Python syntax highlighting
- Add link to pip-tools
- Add whitespace
- Improve heading hierarchy