### PR TITLE
[tarfetch] improve startup output, reduce noise when not needed

### DIFF
--- a/tarfetch/Tiltfile
+++ b/tarfetch/Tiltfile
@@ -64,8 +64,14 @@ def tarfetch(
     if container:
         k8s_object = "{obj} -c {container}".format(obj=k8s_object, container=container)
 
-    target_dir_bat = target_dir.replace("/", "\\")
-    local(["mkdir", "-p", target_dir], command_bat="mkdir {} || ver>nul".format(target_dir_bat))
+    destination_path = os.path.realpath(target_dir)
+    if not os.path.exists(destination_path):
+        print("Preparing destination path for reverse sync:")
+        local(
+            ["mkdir", "-p", destination_path],
+            command_bat="mkdir {} || ver>nul".format(destination_path),
+            quiet = True,
+        )
 
     local_resource(
         name,


### PR DESCRIPTION
## What it Does
- Check whether destination path exists before creating it (reduce noise like example below)
- Explain why `mkdir` command is running in Tilt logs

### Current behavior
```console
Loading Tiltfile at: /home/tim/Code/MyJobs/Tiltfile
local: helm repo list --output yaml 2>/dev/null || true
local: helm search repo ingress-nginx/ingress-nginx --output yaml
local: grep --include='*.yaml' --include='*.yml' -rEil '\bkind[^\w]+CustomResourceDefinition\s*$' /home/tim/.local/share/tilt-dev/.helm/ingress-nginx/latest/ingress-nginx || exit 0
Running: helm template ingress-nginx /home/tim/.local/share/tilt-dev/.helm/ingress-nginx/latest/ingress-nginx --include-crds --namespace ingress-nginx
local: kubectl create configmap certificate-config --from-file root.cert.cnf=./conf/root.cert.cnf --from-file v3.ext=./conf/v3.ext -o=yaml --dry-run=client
local: mkdir -p ../../monolith/src/gulp/
 → [no output]
local: mkdir -p src/
 → [no output]
local: mkdir -p src/
 → [no output]
local: mkdir -p src/
 → [no output]
local: mkdir -p src/
 → [no output]
Successfully loaded Tiltfile (5.878994019s)
```

### PR (when creating destination paths)
```console
Loading Tiltfile at: /home/tim/Code/MyJobs/Tiltfile
...
Preparing destination path for reverse sync:
local: mkdir -p /home/tim/Code/MyJobs/monolith/src/gulp
Preparing destination path for reverse sync:
local: mkdir -p /home/tim/Code/MyJobs/partner_library_service/src
Preparing destination path for reverse sync:
local: mkdir -p /home/tim/Code/MyJobs/company_mapping_service/src
Preparing destination path for reverse sync:
local: mkdir -p /home/tim/Code/MyJobs/compliance_report_service/src
Preparing destination path for reverse sync:
local: mkdir -p /home/tim/Code/MyJobs/monolith/src
Successfully loaded Tiltfile (3.993201185s)
```

### PR (when destination paths already exist)
```console
Loading Tiltfile at: /home/tim/Code/MyJobs/Tiltfile
...
Successfully loaded Tiltfile (4.436321912s)
```