### PR TITLE
Add new docker_build_remote extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,5 @@ v1alpha1.extension(
 
 ## Extensions
 
-- [pip_compile_button](./pip_compile_button) - adds button use pip-compile on requirements in a given resource
+- [docker_build_remote](./docker_build_remote) - Checkout a remote Dockerfile from Git and build it.
+- [pip_compile_button](./pip_compile_button) - Add a pip-compile button to any Tilt resource.

--- a/docker_build_remote/README.md
+++ b/docker_build_remote/README.md
@@ -1,0 +1,25 @@
+# docker_build_remote
+
+Checkout a remote Dockerfile from Git and build it.
+
+## Usage
+
+Works almost identically to [`docker_build`](https://docs.tilt.dev/api.html#api.docker_build), with only one change to 
+the signature. An `repository_url` argument has been added following the image name, and the path to the build 
+context and dockerfile, etc can be passed the same after that.
+
+Builds upon the work of the [`git_resource`](https://github.com/tilt-dev/tilt-extensions/blob/master/git_resource) 
+Tilt extention, which manages the `git checkout` behind the scenes (but sadly did not have a method to simply build 
+the Docker image without also creating a deployment for it).
+
+After importing the repo and extension (see [main README](../README.md)), you can invoke the extension using 
+`docker_build_remote` in your Tiltfile.
+
+```python
+docker_build_remote(
+    "postgres-dev",
+    "git@github.com:postgis/docker-postgis.git",
+    "13-3.3/",
+    extra_tag = "postgres-dev:latest",
+)
+```

--- a/docker_build_remote/Tiltfile
+++ b/docker_build_remote/Tiltfile
@@ -1,0 +1,53 @@
+load('ext://git_resource', 'git_checkout')
+
+
+def docker_build_remote(
+    ref,
+    repository_url,
+    context,
+    build_args = {},
+    dockerfile = 'Dockerfile',
+    dockerfile_contents = '',
+    live_update = [],
+    match_in_env_vars = False,
+    ignore = [],
+    only = [],
+    entrypoint = [],
+    target = '',
+    ssh = '',
+    network = '',
+    secret = [],
+    extra_tag = '',
+    container_args = [],
+    cache_from = [],
+    pull = False,
+    platform = '',
+):
+    """Checkout a remote Dockerfile from Git and build it."""
+    checkout_path = git_checkout(repository_url)
+
+    context = os.path.join(checkout_path, context)
+    kwargs = {
+        "build_args": build_args,
+        "live_update": live_update,
+        "match_in_env_vars": match_in_env_vars,
+        "ignore": ignore,
+        "only": only,
+        "entrypoint": entrypoint,
+        "target": target,
+        "ssh": ssh,
+        "network": network,
+        "secret": secret,
+        "extra_tag": extra_tag,
+        "container_args": container_args,
+        "cache_from": cache_from,
+        "pull": pull,
+        "platform": platform,
+    }
+
+    if dockerfile_contents:
+        kwargs["dockerfile_contents"] = dockerfile_contents
+    else:
+        kwargs["dockerfile"] = os.path.join(context, dockerfile)
+
+    docker_build(ref, context, **kwargs)


### PR DESCRIPTION
New extension to allow a repo to be checked out and then build a Docker image from the repo's content.

This is to allow us to easily build PostGIS from their latest code, since every time a patch is released the old version disappears from the Apt repository and breaks our copy of the Dockerfile (and we must build it ourselves because the official build **only supports x86_64 and not ARM**.
