### PR TITLE
New extension: ingress-nginx

### DIFF
--- a/ingress_nginx/README.md
+++ b/ingress_nginx/README.md
@@ -1,0 +1,21 @@
+# ingress_nginx
+
+Simplify the creation/resource scaffolding of [ingress-nginx](https://kubernetes.github.io/ingress-nginx/) in 
+Kubernetes and Tilt, using the official Helm Chart or plugin (in the case of Minikube).
+
+## Usage
+
+After registering the repo and extension (see [main README](../README.md)), you can invoke the extension using 
+`ingress_nginx()` in your Tiltfile.
+
+```starlark
+load("ext://ingress_nginx", "ingress_nginx")
+
+ingress_nginx(
+    # Optional: Useful for ensuring a secret or configmap containing TLS certificates is ready.
+    resource_deps = ["de-tls"],
+    
+    # Optional: Default is "ingress".
+    labels = ["backend", "ingress"]
+)
+```

--- a/ingress_nginx/Tiltfile
+++ b/ingress_nginx/Tiltfile
@@ -1,0 +1,9 @@
+load("helm/Tiltfile", "load_helmchart")
+load("minikube/Tiltfile", "load_minikube")
+
+
+def ingress_nginx(resource_deps = [], labels = []):
+    if k8s_context() == "minikube":
+        load_minikube(resource_deps, labels)
+    else:
+        load_helmchart(resource_deps, labels)

--- a/ingress_nginx/helm/Tiltfile
+++ b/ingress_nginx/helm/Tiltfile
@@ -1,0 +1,21 @@
+load("ext://helm_resource", "helm_repo", "helm_resource")
+load("ext://namespace", "namespace_create")
+
+REPO_ALIAS = "ingress-nginx-repo"
+LABEL = "ingress"
+
+def load_helmchart(resource_deps = [], labels = []):
+    helm_repo(
+        REPO_ALIAS,
+        url = "https://kubernetes.github.io/ingress-nginx",
+        labels = labels or [LABEL],
+    )
+
+    helm_resource(
+        "ingress-nginx",
+        chart = "%s/ingress-nginx" % REPO_ALIAS,
+        namespace = "ingress-nginx",
+        flags = ["--create-namespace"],
+        resource_deps = [REPO_ALIAS].extend(resource_deps),
+        labels = labels or [LABEL],
+    )

--- a/ingress_nginx/helm/Tiltfile
+++ b/ingress_nginx/helm/Tiltfile
@@ -15,7 +15,10 @@ def load_helmchart(resource_deps = [], labels = []):
         "ingress-nginx",
         chart = "%s/ingress-nginx" % REPO_ALIAS,
         namespace = "ingress-nginx",
-        flags = ["--create-namespace"],
+        flags = [
+            "--create-namespace",
+            "--set=controller.allowSnippetAnnotations=true",
+        ],
         resource_deps = [REPO_ALIAS].extend(resource_deps),
         labels = labels or [LABEL],
     )

--- a/ingress_nginx/minikube/Tiltfile
+++ b/ingress_nginx/minikube/Tiltfile
@@ -1,0 +1,35 @@
+"""Tilt wrapper for Minikube's ingress-nginx plugin."""
+
+LABEL = "ingress"
+
+def load_minikube(resource_deps = [], labels = []):
+    k8s_yaml("k8s/ingressclass.yaml")
+
+    k8s_resource(
+        new_name = "ingress-class",
+        objects = ["nginx:ingressclass"],
+        labels = labels or [LABEL],
+    )
+
+    local_resource(
+        "ingress-nginx",
+        serve_cmd = ["sleep", "infinity"],
+        serve_cmd_bat = "ping -t localhost > NUL",
+        readiness_probe = probe(
+            failure_threshold=3,
+            initial_delay_secs=5,
+            period_secs=10,
+            timeout_secs=2,
+            exec = exec_action([
+                "kubectl",
+                "-n",
+                "ingress-nginx",
+                "rollout",
+                "status",
+                "deployment",
+                "ingress-nginx-controller",
+            ]),
+        ),
+        resource_deps = resource_deps,
+        labels = labels or [LABEL],
+    )

--- a/ingress_nginx/minikube/k8s/ingressclass.yaml
+++ b/ingress_nginx/minikube/k8s/ingressclass.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+  name: nginx
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
+spec:
+  controller: k8s.io/ingress-nginx


### PR DESCRIPTION
Reduce per-project code and maintenance of [ingress-nginx](https://kubernetes.github.io/ingress-nginx/) by putting it into a Tilt extension.

Known issue:
- May not play nice with TLS yet, but the project I'm using it with first (ats-endpoints) does not need it.
