### PR TITLE
tilt_sessions - windows compatibility - make cmd helper function args more optional

### DIFF
--- a/tilt_sessions/Tiltfile
+++ b/tilt_sessions/Tiltfile
@@ -4,8 +4,28 @@ SCRIPTS = os.path.join(os.getcwd(), "scripts")
 CONFIGMAP_NAME = "tilt-active-sessions"
 
 
-def cmd(command, quiet = True, command_bat = "", echo_off = True, env = {}, dir = "", stdin = ""):
-    output = local(command, quiet, command_bat, echo_off, env, dir, stdin)
+def cmd(
+    command,
+    quiet = True,
+    command_bat = None,
+    echo_off = True,
+    env = None,
+    dir = None,
+    stdin = None,
+):
+    kwargs = {}
+
+    # Handle optional keywork arguments
+    if command_bat != None:
+        kwargs["command_bat"] = command_bat
+    if env != None:
+        kwargs["env"] = env
+    if dir != None:
+        kwargs["dir"] = dir
+    if stdin != None:
+        kwargs["stdin"] = stdin
+
+    output = local(command, quiet=quiet, echo_off=echo_off, **kwargs)
     return str(output).strip()
 
 

--- a/tilt_sessions/Tiltfile
+++ b/tilt_sessions/Tiltfile
@@ -64,8 +64,9 @@ def get_session(port = None):
 
 
 def is_active(port = None):
-    script = os.path.join(SCRIPTS, "verify-active.sh")
-    return bool(cmd([script, port]))
+    shell = os.path.join(SCRIPTS, "verify-active.sh")
+    batch = os.path.join(SCRIPTS, "verify-active.bat")
+    return bool(cmd([shell, port], command_bat=[batch, port]))
 
 
 def configmap_exists():

--- a/tilt_sessions/scripts/verify-active.bat
+++ b/tilt_sessions/scripts/verify-active.bat
@@ -1,0 +1,10 @@
+@echo off
+setlocal
+
+set "port=%~1"
+if "%port%"=="" set "port=%TILT_PORT%"
+
+tilt get sessions Tiltfile --ignore-not-found --output name --port %port%
+if %errorlevel% equ 0 (
+  echo true
+)


### PR DESCRIPTION
To test, you will need to edit the `v1alpha1.extension_repo` arguments in a project using our Datadog extension.

For MyJobs, this would be `dev/extensions.Tiltfile` and update the arguments of `v1alpha.extension` to include this branch as `ref`. It will look like below:

```python
v1alpha1.extension_repo(
    name = "de-tilt",
    url = "https://github.com/DirectEmployers/tilt-extensions",
    ref = "tilt_sessions-fix-default-cmd-args-for-windows-compatibility",
)
```

With that change, Tilt will pull the changes from this PR branch and load the Windows compatibility changes.

Everything ought to start without error, and a button to toggle Datadog should be in the upper right-hand corner of the web UI.

![image](https://github.com/DirectEmployers/tilt-extensions/assets/1606132/cb6af9e7-1f8a-4c2b-9949-a663898a895a)
