### PR TITLE
datadog: Use "latest" as DEFAULT_AGENT_TAG

### DIFF
--- a/datadog/Tiltfile
+++ b/datadog/Tiltfile
@@ -14,7 +14,7 @@ DD_KEY_FILE = os.path.join(DD_USER_CONFIG_PATH, ".keys.env")
 WORKLOAD_NAME = "datadog-agent"
 BUTTON_NAME = "de-remote:toggle-datadog-agent"
 
-DEFAULT_AGENT_TAG = "7"
+DEFAULT_AGENT_TAG = "latest"
 MINIMUM_AGENT_VERSION = 7
 
 


### PR DESCRIPTION
As you can see on the [Google Cloud repository][0], there is no image tagged as "7". The freshest image is "latest", so I changed the default to that.

[0]: https://console.cloud.google.com/artifacts/docker/datadoghq/us/gcr.io/cluster-agent