### PR TITLE
[ingress-nginx] set nginx as default ingressClass

### DIFF
--- a/ingress_nginx/helm/Tiltfile
+++ b/ingress_nginx/helm/Tiltfile
@@ -18,6 +18,7 @@ def load_helmchart(resource_deps = [], labels = []):
         flags = [
             "--create-namespace",
             "--set=controller.allowSnippetAnnotations=true",
+            "--set=controller.ingressClassResource.default=true",
         ],
         resource_deps = [REPO_ALIAS].extend(resource_deps),
         labels = labels or [LABEL],


### PR DESCRIPTION
The ingress-nginx Helm Chart [does not set Nginx as the default ingress class by default](https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml#L126). This sets that value for the convenience of our dev environments, which only use nginx at the moment.