### PR TITLE
[tarfetch] Remove argument that is unavailable in the busybox version of tar

### DIFF
--- a/tarfetch/Tiltfile
+++ b/tarfetch/Tiltfile
@@ -78,7 +78,7 @@ def tarfetch(
         (
             "(" +
             "kubectl exec -i -n {namespace} {k8s_object} -- " +
-            "tar -c -f - --atime-preserve=system --directory={src_dir} {exclude} ." +
+            "tar -c -f - --directory={src_dir} {exclude} ." +
             ") | " +
             "tar -x -f - {verbose} {keep_newer} --directory={target_dir} && " +
             "echo Done."


### PR DESCRIPTION
Alpine uses busybox for its basic utilities including `tar`, and [does not support](https://www.busybox.net/downloads/BusyBox.html#tar) the `--atime-preserve` argument.