### PR TITLE
ingress-nginx: list.extend returns None and breaks resource_deps

### DIFF
--- a/ingress_nginx/helm/Tiltfile
+++ b/ingress_nginx/helm/Tiltfile
@@ -5,6 +5,8 @@ REPO_ALIAS = "ingress-nginx-repo"
 LABEL = "ingress"
 
 def load_helmchart(resource_deps = [], labels = []):
+    resource_deps.append(REPO_ALIAS)
+
     helm_repo(
         REPO_ALIAS,
         url = "https://kubernetes.github.io/ingress-nginx",
@@ -20,6 +22,6 @@ def load_helmchart(resource_deps = [], labels = []):
             "--set=controller.allowSnippetAnnotations=true",
             "--set=controller.ingressClassResource.default=true",
         ],
-        resource_deps = [REPO_ALIAS].extend(resource_deps),
+        resource_deps = resource_deps,
         labels = labels or [LABEL],
     )


### PR DESCRIPTION
Fix resource_deps parsing to allow arguments and default (helm chart repo) to be combined properly.