### PR TITLE
New Extension: MotoServer

### DIFF
--- a/motoserver/Dockerfile
+++ b/motoserver/Dockerfile
@@ -1,0 +1,4 @@
+FROM motoserver/moto:5.0.12
+
+COPY main.py ./
+ENTRYPOINT python3 -m main

--- a/motoserver/Dockerfile
+++ b/motoserver/Dockerfile
@@ -1,7 +1,13 @@
 FROM motoserver/moto:5.0.12
 
-# Install AWS CLI
-RUN apt-get install -y awscli && rm -rf /var/lib/apt/lists/*
+ENV AWS_ACCESS_KEY_ID="test" \
+    AWS_SECRET_ACCESS_KEY="test" \
+    AWS_DEFAULT_REGION="us-east-1" \
+    AWS_ENDPOINT_URL="http://localhost:3000" \
+    AWS_DEFAULT_OUTPUT="json" \
+    AWS_PAGER=""
+
+RUN pip --no-cache-dir install awscli-local[ver1]
 
 COPY main.py ./
 ENTRYPOINT python3 -m main

--- a/motoserver/Dockerfile
+++ b/motoserver/Dockerfile
@@ -1,4 +1,7 @@
 FROM motoserver/moto:5.0.12
 
+# Install AWS CLI
+RUN apt-get install -y awscli && rm -rf /var/lib/apt/lists/*
+
 COPY main.py ./
 ENTRYPOINT python3 -m main

--- a/motoserver/README.md
+++ b/motoserver/README.md
@@ -51,8 +51,10 @@ motoserver_up(init_script="path/to/your/init.sh")
 motoserver_up(
     init_script="""
     #!/usr/bin/env sh
+    echo "=============================================================================================="
     echo "This is a placeholder for a MotoServer init script. See the extension readme for more details!"
     echo "URL: https://github.com/DirectEmployers/tilt-extensions/blob/main/motoserver/README.md"
+    echo "=============================================================================================="
     """
 )
 ```

--- a/motoserver/README.md
+++ b/motoserver/README.md
@@ -40,7 +40,9 @@ motoserver(labels=["motoserver", "support"])
 
 ### Provide an initialization script
 An init script can be provided via path or string using the `init_script` keyword argument. It will be added to a 
-ConfigMap and run during server startup by the Python script in `src/main.py`.
+ConfigMap and run during server startup by the Python script in `src/main.py`. Note: your init commands should be
+idempotent to prevent duplicate data or errors from occurring (i.e. use checks to prevent existing resources from
+being recreated).
 
 ```starlark
 motoserver_up(init_script="path/to/your/init.sh")

--- a/motoserver/README.md
+++ b/motoserver/README.md
@@ -25,11 +25,36 @@ v1alpha1.extension(
 ```
 
 ### Import and call the extension
+Here is the simplest way to get MotoServer running.
+
 ```starlark
 load("ext://motoserver", "motoserver_up")
 
 motoserver_up()
 ```
+
+You can also set any labels you may wish MotoServer resources to use:
+```starlark
+motoserver(labels=["motoserver", "support"])
+```
+
+### Provide an initialization script
+An init script can be provided via path or string using the `init_script` keyword argument. It will be added to a 
+ConfigMap and run during server startup by the Python script in `src/main.py`.
+
+```starlark
+motoserver_up(init_script="path/to/your/init.sh")
+
+# or with a string
+motoserver_up(
+    init_script="""
+    #!/usr/bin/env sh
+    echo "This is a placeholder for a MotoServer init script. See the extension readme for more details!"
+    echo "URL: https://github.com/DirectEmployers/tilt-extensions/blob/main/motoserver/README.md"
+    """
+)
+```
+
 
 #### App Integration using environment variable
 After successfully starting, MotoServer should be available within the cluster at `http://motoserver:3000`. 

--- a/motoserver/README.md
+++ b/motoserver/README.md
@@ -1,0 +1,58 @@
+# Moto Server
+
+MotoServer emulates AWS resources for development, using a lightly modified version of the official [Moto Docker image](https://hub.docker.com/r/motoserver/moto).
+
+## Usage
+
+After registering the repo and extension (see [main README](../README.md) for more details), you can invoke the extension using 
+`motoserver_up()` in your Tiltfile.
+
+### Register the extension repo
+```starlark
+v1alpha1.extension_repo(
+    name = "de-tilt",
+    url = "https://github.com/DirectEmployers/tilt-extensions",
+)
+```
+
+### Register the `motoserver` extension
+```starlark
+v1alpha1.extension(
+    name = "motoserver",
+    repo_name = "de-tilt",
+    repo_path = "motoserver",
+)
+```
+
+### Import and call the extension
+```starlark
+load("ext://motoserver", "motoserver_up")
+
+motoserver_up()
+```
+
+#### App Integration using environment variable
+After successfully starting, MotoServer should be available within the cluster at `http://motoserver:3000`. 
+A limited web dashboard is also available at http://motoserver:3000/moto-api/ 
+(after updating your hosts file to include `motoserver`).
+
+The simplest way use MotoServer for all AWS requests in your development environment is by using the `AWS_ENDPOINT_URL`
+environment variable in your app containers. [Service-specific endpoints](https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html) can also be used if required for one-off exceptions.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  selector:
+    matchLabels:
+      app: myapp
+  template:
+    spec:
+      containers:
+        - name: myapp
+          env:
+            - name: AWS_ENDPOINT_URL
+              value: "http://motoserver:3000"
+```

--- a/motoserver/README.md
+++ b/motoserver/README.md
@@ -44,6 +44,10 @@ ConfigMap and run during server startup by the Python script in `src/main.py`. N
 idempotent to prevent duplicate data or errors from occurring (i.e. use checks to prevent existing resources from
 being recreated).
 
+> **Important:** The default account ID is `123456789012`. If you have trouble finding resources which ought to exist,
+> please try again with an ARN which includes the default region and account ID
+> (i.e. arn:aws:sns:us-east-1:123456789012:test_topic).
+
 ```starlark
 motoserver_up(init_script="path/to/your/init.sh")
 

--- a/motoserver/README.md
+++ b/motoserver/README.md
@@ -55,6 +55,9 @@ motoserver_up(
 )
 ```
 
+> **Note:** If you encounter trouble with string parsing, you can find more detail about how strings behave in the 
+> [Starlark documentation](https://github.com/bazelbuild/starlark/blob/master/spec.md).
+
 
 #### App Integration using environment variable
 After successfully starting, MotoServer should be available within the cluster at `http://motoserver:3000`. 

--- a/motoserver/Tiltfile
+++ b/motoserver/Tiltfile
@@ -4,33 +4,50 @@ load("../devcore/Tiltfile", "tilt_port")
 extension_root = os.getcwd()
 
 
-def motoserver_up(add_buttons = True, labels = []):
+def motoserver_up(init_script = "", labels = []):
     """Deploy MotoServer using Docker and Kubernetes."""
 
     docker_build(
         "motoserver-persistence",
-        context=os.path.join(extension_root,"src/"),
-        dockerfile=os.path.join(extension_root, "Dockerfile"),
+        context = os.path.join(extension_root, "src/"),
+        dockerfile = os.path.join(extension_root, "Dockerfile"),
     )
+
+    if not init_script:
+         init_script = read_file(os.path.join(extension_root, "scripts/init.sh"))
+    else:
+        # If `init_script` is a file path, return its contents. Otherwise, treat it as a string.
+        init_script = read_file(init_script, init_script)
 
     k8s_yaml([
         os.path.join(extension_root, "k8s/moto-statefulset.yaml"),
         os.path.join(extension_root, "k8s/moto-service.yaml"),
     ])
+    k8s_yaml(init_script_configmap_yaml("motoserver-init-script", init_script))
 
     k8s_resource(
         "motoserver",
-        port_forwards=[
-            "motoserver:3000:3000",
-        ],
-        links=[
-            "http://motoserver:3000/moto-api/",
-        ],
-        labels=labels,
+        port_forwards = ["motoserver:3000:3000"],
+        objects = ["motoserver-init-script:configmap"],
+        links = ["http://motoserver:3000/moto-api/"],
+        labels = labels,
     )
 
-    if add_buttons:
-        add_ui_buttons()
+    add_ui_buttons()
+
+
+def init_script_configmap_yaml(name, data):
+    template = {
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {
+            "name": name,
+        },
+        "data": {
+            "init.sh": str(data)
+        },
+    }
+    return encode_yaml(template)
 
 
 def add_ui_buttons():

--- a/motoserver/Tiltfile
+++ b/motoserver/Tiltfile
@@ -4,7 +4,7 @@ load("../devcore/Tiltfile", "tilt_port")
 extension_root = os.getcwd()
 
 
-def motoserver_up(add_buttons = True):
+def motoserver_up(add_buttons = True, labels = []):
     """Deploy MotoServer using Docker and Kubernetes."""
 
     docker_build(
@@ -26,6 +26,7 @@ def motoserver_up(add_buttons = True):
         links=[
             "http://motoserver:3000/moto-api/",
         ],
+        labels=labels,
     )
 
     if add_buttons:

--- a/motoserver/Tiltfile
+++ b/motoserver/Tiltfile
@@ -1,0 +1,47 @@
+load("ext://uibutton", "cmd_button")
+load("../devcore/Tiltfile", "tilt_port")
+
+extension_root = os.getcwd()
+
+
+def motoserver_up(add_buttons = True):
+    """Deploy MotoServer using Docker and Kubernetes."""
+
+    docker_build(
+        "motoserver-persistence",
+        context="./src/",
+        dockerfile="./Dockerfile",
+    )
+
+    k8s_yaml([
+        "k8s/moto-statefulset.yaml",
+        "k8s/moto-service.yaml",
+    ])
+
+    k8s_resource(
+        "motoserver",
+        port_forwards=[
+            "motoserver:3000:3000",
+        ],
+        links=[
+            "http://motoserver:3000/moto-api/",
+        ],
+    )
+
+    if add_buttons:
+        add_ui_buttons()
+
+
+def add_ui_buttons():
+    """Add UI Buttons to toggle MotoServer and reset data."""
+    port = tilt_port()
+
+    toggle_script = os.path.join(extension_root, "scripts/toggle.sh")
+    icon = "cloud" if "motoserver" in sys.argv or not sys.argv[2:] else "cloud_off"
+    cmd_button(
+        "motoserver:toggle",
+        argv = ["sh", toggle_script, port],
+        location = "nav",
+        icon_name = icon,
+        text = "Toggle MotoServer",
+    )

--- a/motoserver/Tiltfile
+++ b/motoserver/Tiltfile
@@ -14,8 +14,8 @@ def motoserver_up(add_buttons = True, labels = []):
     )
 
     k8s_yaml([
-        "k8s/moto-statefulset.yaml",
-        "k8s/moto-service.yaml",
+        os.path.join(extension_root, "k8s/moto-statefulset.yaml"),
+        os.path.join(extension_root, "k8s/moto-service.yaml"),
     ])
 
     k8s_resource(

--- a/motoserver/Tiltfile
+++ b/motoserver/Tiltfile
@@ -9,8 +9,8 @@ def motoserver_up(add_buttons = True, labels = []):
 
     docker_build(
         "motoserver-persistence",
-        context="./src/",
-        dockerfile="./Dockerfile",
+        context=os.path.join(extension_root,"src/"),
+        dockerfile=os.path.join(extension_root, "Dockerfile"),
     )
 
     k8s_yaml([

--- a/motoserver/k8s/moto-service.yaml
+++ b/motoserver/k8s/moto-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: motoserver
+  labels:
+    app: motoserver
+  annotations:
+    tilt.dev/down-policy: keep
+spec:
+  ports:
+  - port: 3000
+    name: motoserver
+  clusterIP: None
+  selector:
+    app: motoserver

--- a/motoserver/k8s/moto-statefulset.yaml
+++ b/motoserver/k8s/moto-statefulset.yaml
@@ -20,16 +20,14 @@ spec:
         tty: true
         stdin: true
         env:
+          - name: MOTO_SERVER_IP
+            value: "0.0.0.0"
+          - name: MOTO_PORT
+            value: "3000"
           - name: MOTO_RECORDER_FILEPATH
             value: "/usr/share/motoserver/state.json"
           - name: MOTO_ENABLE_RECORDING
             value: "True"
-          - name: MOTO_PORT
-            value: "3000"
-          - name: MOTO_SERVER_IP
-            value: "0.0.0.0"
-          - name: AWS_ENDPOINT_URL
-            value: "http://0.0.0.0:3000"
         ports:
         - containerPort: 3000
           name: motoserver

--- a/motoserver/k8s/moto-statefulset.yaml
+++ b/motoserver/k8s/moto-statefulset.yaml
@@ -28,6 +28,8 @@ spec:
             value: "3000"
           - name: MOTO_SERVER_IP
             value: "0.0.0.0"
+          - name: AWS_ENDPOINT_URL
+            value: "http://0.0.0.0:3000"
         ports:
         - containerPort: 3000
           name: motoserver

--- a/motoserver/k8s/moto-statefulset.yaml
+++ b/motoserver/k8s/moto-statefulset.yaml
@@ -34,6 +34,15 @@ spec:
         volumeMounts:
         - name: motoserver-storage
           mountPath: /usr/share/motoserver/
+        - name: init-script
+          mountPath: /motoserver/
+      volumes:
+      - name: init-script
+        configMap:
+          name: motoserver-init-script
+          items:
+            - key: init.sh
+              path: init.sh
   volumeClaimTemplates:
   - metadata:
       name: motoserver-storage

--- a/motoserver/k8s/moto-statefulset.yaml
+++ b/motoserver/k8s/moto-statefulset.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: motoserver
+spec:
+  selector:
+    matchLabels:
+      app: motoserver
+  serviceName: "motoserver"
+  template:
+    metadata:
+      labels:
+        app: motoserver
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: motoserver
+        image: motoserver-persistence
+        imagePullPolicy: IfNotPresent
+        tty: true
+        stdin: true
+        env:
+          - name: MOTO_RECORDER_FILEPATH
+            value: "/usr/share/motoserver/state.json"
+          - name: MOTO_ENABLE_RECORDING
+            value: "True"
+          - name: MOTO_PORT
+            value: "3000"
+          - name: MOTO_SERVER_IP
+            value: "0.0.0.0"
+        ports:
+        - containerPort: 3000
+          name: motoserver
+        volumeMounts:
+        - name: motoserver-storage
+          mountPath: /usr/share/motoserver/
+  volumeClaimTemplates:
+  - metadata:
+      name: motoserver-storage
+      annotations:
+        tilt.dev/down-policy: keep
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 100Mi

--- a/motoserver/scripts/init.sh
+++ b/motoserver/scripts/init.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+echo "=============================================================================================="
+echo "This is a placeholder for a MotoServer init script. See the extension readme for more details!"
+echo "URL: https://github.com/DirectEmployers/tilt-extensions/blob/main/motoserver/README.md"
+echo "=============================================================================================="

--- a/motoserver/scripts/toggle.sh
+++ b/motoserver/scripts/toggle.sh
@@ -5,9 +5,9 @@ port=${1:-10350}
 status=$(tilt get uiresources motoserver --port "$port" --output jsonpath='{.status.disableStatus.state}')
 
 if [ "$status" = "Enabled" ]; then
-  tilt disable --port "$port" --labels motoserver
+  tilt disable --port "$port" motoserver
 else
-  tilt enable --port "$port" --labels motoserver
+  tilt enable --port "$port" motoserver
 fi
 
 sh update-button.sh "$port"

--- a/motoserver/scripts/toggle.sh
+++ b/motoserver/scripts/toggle.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+cd "$(dirname "$0")" || exit
+
+port=${1:-10350}
+status=$(tilt get uiresources motoserver --port "$port" --output jsonpath='{.status.disableStatus.state}')
+
+if [ "$status" = "Enabled" ]; then
+  tilt disable --port "$port" --labels motoserver
+else
+  tilt enable --port "$port" --labels motoserver
+fi
+
+sh update-button.sh "$port"

--- a/motoserver/scripts/update-button.sh
+++ b/motoserver/scripts/update-button.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+port=${1:-10350}
+status=$(tilt get uiresources motoserver --port "$port" --output jsonpath='{.status.disableStatus.state}')
+
+icon="cloud_off"
+if [ "$status" = "Enabled" ]; then
+  icon="cloud"
+fi
+
+tilt patch uibutton motoserver:toggle --port "$port" -p "{\"spec\": {\"iconName\": \"$icon\"}}"

--- a/motoserver/src/main.py
+++ b/motoserver/src/main.py
@@ -1,0 +1,76 @@
+import json
+import os
+import signal
+from pathlib import Path
+
+from moto.moto_api import recorder
+from moto.server import ThreadedMotoServer, signal_handler
+
+
+PORT = os.environ.get("MOTO_PORT", "5000")
+IP_ADDRESS = os.environ.get("MOTO_SERVER_IP", "0.0.0.0")
+STATE_FILE = Path(os.environ.get("MOTO_RECORDER_FILEPATH"))
+
+try:
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+except ValueError:
+    pass  # ignore "ValueError: signal only works in main thread"
+
+
+def compact_state():
+    """Compact the Moto Recorder state file to avoid making unnecessary requests."""
+    compacted = []
+
+    try:
+        state = recorder.download_recording()
+        with STATE_FILE.open("w") as file:
+            for line in state.splitlines():
+                request = json.loads(line)
+
+                # Skip all read requests; they don't affect state.
+                if request.get("method") in ["GET", "HEAD", "OPTIONS"]:
+                    continue
+
+                # These headers vary too much without affecting the actual requests,
+                # we remove them to improve the consistency during deduplication.
+                varying_headers = ["Authorization", "X-Amz-Date"]
+
+                comparable_headers = {
+                    k: v
+                    for k, v in request["headers"].items()
+                    if k not in varying_headers
+                }
+                simple_request = dict(request, headers=comparable_headers)
+
+                # Write original JSON line back, with linebreak.
+                if simple_request not in compacted:
+                    file.write(f"{line}\n")
+                    compacted.append(simple_request)
+    except FileNotFoundError:
+        pass
+
+
+def restore_state(
+    ip_address: str = "0.0.0.0", port: str = "5000", scheme: str = "http"
+):
+    """Restore state from Moto Recorder state file."""
+    try:
+        # Restore state from file.
+        print("Restoring MotoServer state...")
+        recorder.replay_recording(f"{scheme}://{ip_address}:{port}")
+    except FileNotFoundError:
+        pass
+
+
+if __name__ == "__main__":
+    # Start server
+    server = ThreadedMotoServer(IP_ADDRESS, PORT)
+    server.start()
+
+    compact_state()
+    restore_state(IP_ADDRESS, PORT)
+
+    # Keep server alive and prevent script from ending!
+    print("MotosServer is ready!")
+    server._thread.join()

--- a/motoserver/src/main.py
+++ b/motoserver/src/main.py
@@ -2,6 +2,7 @@ import json
 import os
 import signal
 from pathlib import Path
+from subprocess import run
 
 from moto.moto_api import recorder
 from moto.server import ThreadedMotoServer, signal_handler
@@ -63,13 +64,22 @@ def restore_state(
         pass
 
 
+def run_init_script():
+    print("Initializing resources...")
+    run(["sh", "/motoserver/init.sh"])
+
+
 if __name__ == "__main__":
     # Start server
     server = ThreadedMotoServer(IP_ADDRESS, PORT)
     server.start()
 
+    # Restore prior state
     compact_state()
     restore_state(IP_ADDRESS, PORT)
+
+    # Initialize resources
+    run_init_script()
 
     # Keep server alive and prevent script from ending!
     print("MotosServer is ready!")

--- a/motoserver/tests/basic/Tiltfile
+++ b/motoserver/tests/basic/Tiltfile
@@ -1,0 +1,3 @@
+load("../../Tiltfile", "motoserver_up")
+
+motoserver_up()

--- a/motoserver/tests/init_awscli/Tiltfile
+++ b/motoserver/tests/init_awscli/Tiltfile
@@ -1,0 +1,21 @@
+load("../../Tiltfile", "motoserver_up")
+
+
+motoserver_up(
+    init_script="""
+    #!/usr/bin/env sh
+    echo "Creating S3 Buckets"
+    aws s3api create-bucket --bucket gitops
+    aws s3api create-bucket --bucket jobsfs
+    aws s3api create-bucket --bucket de-microsites
+
+    echo "Creating SNS Topics and Subscriptions"
+    aws sns create-topic --name job_source_updates_s3
+    aws sns subscribe \
+        --protocol http \
+        --topic-arn arn:aws:sns:us-east-1:123456789012:job_source_updates_s3 \
+        --notification-endpoint http://imports-service-api.default.svc.cluster.local:8000/api/import
+
+    echo "Done."
+    """
+)

--- a/motoserver/tests/init_path/Tiltfile
+++ b/motoserver/tests/init_path/Tiltfile
@@ -1,0 +1,3 @@
+load("../../Tiltfile", "motoserver_up")
+
+motoserver_up(init_script="../../scripts/init.sh")

--- a/motoserver/tests/init_string/Tiltfile
+++ b/motoserver/tests/init_string/Tiltfile
@@ -1,0 +1,10 @@
+load("../../Tiltfile", "motoserver_up")
+
+motoserver_up(
+    init_script="""
+    #!/usr/bin/env sh
+    echo "========================================"
+    echo "Test with init script passed via string!"
+    echo "========================================"
+    """
+)


### PR DESCRIPTION
## What this PR Does
Deploy MotoServer in your local development environment to run emulated/mocked AWS infrastructure locally.

State is maintained via a JSON file in a K8s persistent volume. There is the potential for this setup to slow down overtime, though I've attempted to mitigate that with some code that runs on startup (see `main.py`). If that becomes an issue, I can create a button to trigger an internal reset of the state.

## Notes to the Reviewer
You will need to point at this branch when registering the custom extension repo:
```python
v1alpha1.extension_repo(
    "de-tilt",
    url = "https://github.com/DirectEmployers/tilt-extensions",
    ref="motoserver",
)

v1alpha1.extension(
    name = "motoserver",
    repo_name = "de-tilt",
    repo_path = "motoserver",
)
```