### PR TITLE
ingress_nginx: Update and refactor

### DIFF
--- a/ingress_nginx/README.md
+++ b/ingress_nginx/README.md
@@ -1,21 +1,34 @@
 # ingress_nginx
 
-Simplify the creation/resource scaffolding of [ingress-nginx](https://kubernetes.github.io/ingress-nginx/) in 
-Kubernetes and Tilt, using the official Helm Chart or plugin (in the case of Minikube).
+Simplify the creation/resource scaffolding of the [NGINX Ingress Controller for Kubernetes](https://kubernetes.github.io/ingress-nginx/) in Tilt, using the official Helm Chart or Minikube plugin.
+
+## Reference
+
+All arguments for `ingress_nginx()` are optional:
+
+- `resource_deps: list[str] = []`
+
+   Specify resources that must exist before the controller may start, such as a secret or a ConfigMap containing TLS certificates. See [Resource Dependencies in the Tilt docs](https://docs.tilt.dev/resource_dependencies.html).
+
+- `labels: str | list[str] = []`
+
+    Add the ingress controller to a group in the Tilt web UI. See [Resource Groups in the Tilt docs](https://docs.tilt.dev/tiltfile_concepts.html#resource-groups). Defaults to `["ingress"]`.
+
+- `helm_chart_version: str | None = None`
+
+    Specify the version of the [ingress-ningx Helm Chart](https://github.com/kubernetes/ingress-nginx/releases?q=helm-chart&expanded=true) to use. Defaults to the latest version. Doesn't do anything when using Minikube.
 
 ## Usage
 
-After registering the repo and extension (see [main README](../README.md)), you can invoke the extension using 
+After registering the repo and extension (see [main README](../README.md)), you can invoke the extension using
 `ingress_nginx()` in your Tiltfile.
 
 ```starlark
 load("ext://ingress_nginx", "ingress_nginx")
 
 ingress_nginx(
-    # Optional: Useful for ensuring a secret or configmap containing TLS certificates is ready.
     resource_deps = ["de-tls"],
-    
-    # Optional: Default is "ingress".
     labels = ["backend", "ingress"]
+    helm_chart_version = "4.12.0"
 )
 ```

--- a/ingress_nginx/Tiltfile
+++ b/ingress_nginx/Tiltfile
@@ -1,9 +1,8 @@
 load("helm/Tiltfile", "load_helmchart")
 load("minikube/Tiltfile", "load_minikube")
 
-
-def ingress_nginx(resource_deps = [], labels = []):
+def ingress_nginx(resource_deps = [], labels = [], helm_chart_version = None):
     if k8s_context() == "minikube":
         load_minikube(resource_deps, labels)
     else:
-        load_helmchart(resource_deps, labels)
+        load_helmchart(resource_deps, labels, chart_version = helm_chart_version)

--- a/ingress_nginx/Tiltfile
+++ b/ingress_nginx/Tiltfile
@@ -1,3 +1,4 @@
+"""Define the top-level `ingress_nginx()` function."""
 load("helm/Tiltfile", "load_helmchart")
 load("minikube/Tiltfile", "load_minikube")
 

--- a/ingress_nginx/helm/Tiltfile
+++ b/ingress_nginx/helm/Tiltfile
@@ -1,9 +1,21 @@
+"""Define the top-level `load_helmchart()` function."""
 load("ext://helm_resource", "helm_repo", "helm_resource")
 
 REPO_ALIAS = "ingress-nginx-repo"
 LABEL = "ingress"
 
 def load_helmchart(resource_deps = [], labels = [], chart_version = None):
+    """
+    Create a helm_resource from the ingress-nginx Helm Chart.
+
+    Args:
+        resource_deps: Specify resources that must exist before the controller
+            may start. The Helm repo resource is added automatically.
+        labels: Add the ingress controller to a group in the Tilt web UI.
+            Default is `["ingress"]`.
+        chart_version: Specify the version of the ingress-ningx Helm Chart to use.
+            Default is latest.
+    """
     helm_repo(
         REPO_ALIAS,
         url = "https://kubernetes.github.io/ingress-nginx",

--- a/ingress_nginx/helm/Tiltfile
+++ b/ingress_nginx/helm/Tiltfile
@@ -1,27 +1,28 @@
 load("ext://helm_resource", "helm_repo", "helm_resource")
-load("ext://namespace", "namespace_create")
 
-CHART_VERSION = "4.11.4"
 REPO_ALIAS = "ingress-nginx-repo"
 LABEL = "ingress"
 
-def load_helmchart(resource_deps = [], labels = [], chart_version = CHART_VERSION):
+def load_helmchart(resource_deps = [], labels = [], chart_version = None):
     helm_repo(
         REPO_ALIAS,
         url = "https://kubernetes.github.io/ingress-nginx",
         labels = labels or [LABEL],
     )
 
+    helm_flags = [
+        "--create-namespace",
+        "--set=controller.allowSnippetAnnotations=true",
+        "--set=controller.ingressClassResource.default=true",
+    ]
+    if chart_version:
+        helm_flags.append("--version=%s" % chart_version)
+
     helm_resource(
         "ingress-nginx",
         chart = "%s/ingress-nginx" % REPO_ALIAS,
         namespace = "ingress-nginx",
-        flags = [
-            "--create-namespace",
-            "--version=%s" % chart_version,
-            "--set=controller.allowSnippetAnnotations=true",
-            "--set=controller.ingressClassResource.default=true",
-        ],
+        flags = helm_flags,
         resource_deps = [REPO_ALIAS] + resource_deps,
         labels = labels or [LABEL],
     )


### PR DESCRIPTION
Improves the ergonomics of the `ingress_nginx` plugin:

- No longer defaults to a specific version of the Helm Chart, which had become stale. Instead, it pulls the latest version by default. A new optional `helm_chart_version` argument is added to `ingress_nginx()` to control the chart version (missed in #25).
- Rewrote the README with explicit documentation.
- Added docstrings to `ingress_nginx/helm/Tiltfile`.