### PR TITLE
[Ingress Nginx] Add annotations-risk-level annotation to allow SnippetAnnotations to work

### DIFF
--- a/ingress_nginx/helm/Tiltfile
+++ b/ingress_nginx/helm/Tiltfile
@@ -25,6 +25,7 @@ def load_helmchart(resource_deps = [], labels = [], chart_version = None):
     helm_flags = [
         "--create-namespace",
         "--set=controller.allowSnippetAnnotations=true",
+        "--set=controller.config.annotations-risk-level=Critical",
         "--set=controller.ingressClassResource.default=true",
     ]
     if chart_version:


### PR DESCRIPTION
I began seeing this error on Friday:
```
Error: UPGRADE FAILED: cannot patch "xyz" with kind Ingress: admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: annotation group ConfigurationSnippet contains risky annotation based on ingress configuration
```

I found a blog describing an annotation to silence it (https://ellie.wtf/notes/ingress-nginx-risky-annotations). After adding the annotation to increase the risk-level to Critical, the extension began working for me again.

TL:DR; After controller v1.12, you need to [adjust your accepted risk level](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations-risk/) via `annotations-risk-level` in addition to specifying `allowSnippetAnnotations: true` (ConfigurationSnippet is marked Critical).
