### PR TITLE
motoserver: Fix init_script handling error on Windows

### DIFF
--- a/motoserver/Tiltfile
+++ b/motoserver/Tiltfile
@@ -13,11 +13,13 @@ def motoserver_up(init_script = "", **k8s_kwargs):
         dockerfile = os.path.join(extension_root, "Dockerfile"),
     )
 
-    if not init_script:
-         init_script = read_file(os.path.join(extension_root, "scripts/init.sh"))
+    if init_script:
+        # If `init_script` contains a newline, it's not a path
+        not_path = "\n" in init_script
+        # Treat `init_script` as a script if it isn't a path
+        init_script = init_script if not_path else read_file(init_script, default=init_script)
     else:
-        # If `init_script` is a file path, return its contents. Otherwise, treat it as a string.
-        init_script = read_file(init_script, init_script)
+        init_script = read_file(os.path.join(extension_root, "scripts/init.sh"))
 
     k8s_yaml([
         os.path.join(extension_root, "k8s/moto-statefulset.yaml"),


### PR DESCRIPTION
The `motoserver_up` invocation in [DirectEmployers/MyJobs/blob/quality-control/dev/microsites/Tiltfile][0] resulted in a [runtime exception on Aladeen's Windows machine][1]:

```
Error: Traceback (most recent call last):
  D:\dev\MyJobs\Tiltfile:3:13: in <toplevel>
  <builtin>: in load_dynamic
  D:\dev\MyJobs\apollo_gateway\Tiltfile:2:13: in <toplevel>
  <builtin>: in load_dynamic
  D:\dev\MyJobs\partner_library_service\Tiltfile:4:13: in <toplevel>
  <builtin>: in load_dynamic
  D:\dev\MyJobs\dev\Tiltfile:14:13: in <toplevel>
  <builtin>: in load_dynamic
  D:\dev\MyJobs\dev\microsites\Tiltfile:35:14: in <toplevel>
  C:\Users\AladeenLababneh\AppData\Local\tilt-dev\tilt_modules\github.com\DirectEmployers\tilt-extensions\motoserver\Tiltfile:20:32: in motoserver_up
Error in read_file: CreateFile D:\dev\MyJobs\dev\microsites\
    #!\usr\bin\env sh
    echo "Creating s3 buckets in moto..."

    if awslocal s3api head-bucket --bucket gitops 2>\dev\null; then
        echo "Bucket gitops already exists"
    else
        awslocal s3api create-bucket --bucket gitops
    fi
    if awslocal s3api head-bucket --bucket jobsfs 2>\dev\null; then
        echo "Bucket jobsfs already exists"
    else
        awslocal s3api create-bucket --bucket jobsfs
    fi

    if awslocal s3api head-bucket --bucket de-microsites 2>\dev\null; then
        echo "Bucket de-microsites already exists"
    else
        awslocal s3api create-bucket --bucket de-microsites
    fi
    : The filename, directory name, or volume label syntax is incorrect.
```

The [read_file][2] function tried to construct a path out of the script text and an unhandled system exception occurred.

To try to mitigate this, I used a heuristic: If `init_script` contains `\n`, then it is probably **not a path**, so don't call `read_file`.

[0]: https://github.com/DirectEmployers/MyJobs/blob/ca68994f66fca1a9b71c8e2b493a232f807f0de8/dev/microsites/Tiltfile#L35-L58
[1]: https://directemployers.slack.com/archives/C07005WH679/p1744891523409949
[2]: https://docs.tilt.dev/api.html#api.read_file