### PR TITLE
ingress_nginx: Add custom Helm flags

### DIFF
--- a/ingress_nginx/README.md
+++ b/ingress_nginx/README.md
@@ -18,6 +18,17 @@ All arguments for `ingress_nginx()` are optional:
 
     Specify the version of the [ingress-ningx Helm Chart](https://github.com/kubernetes/ingress-nginx/releases?q=helm-chart&expanded=true) to use. Defaults to the latest version. Doesn't do anything when using Minikube.
 
+- `helm_flags: list[str] = []`
+
+    Pass custom flags to the `flags` argument of [`helm_resource`](https://github.com/tilt-dev/tilt-extensions/tree/master/helm_resource#helm_resource), <i>e.g.</i> `['--set=key=value']`.
+
+    Flags that are always passed:
+
+    - `--create-namespace`
+    - `--set=controller.allowSnippetAnnotations=true`
+    - `--set=controller.config.annotations-risk-level=Critical`
+    - `--set=controller.ingressClassResource.default=true`
+
 ## Usage
 
 After registering the repo and extension (see [main README](../README.md)), you can invoke the extension using

--- a/ingress_nginx/Tiltfile
+++ b/ingress_nginx/Tiltfile
@@ -1,9 +1,19 @@
 """Define the top-level `ingress_nginx()` function."""
+
 load("helm/Tiltfile", "load_helmchart")
 load("minikube/Tiltfile", "load_minikube")
 
-def ingress_nginx(resource_deps = [], labels = [], helm_chart_version = None):
+def ingress_nginx(
+        resource_deps = [],
+        labels = [],
+        helm_chart_version = None,
+        helm_flags = []):
     if k8s_context() == "minikube":
         load_minikube(resource_deps, labels)
     else:
-        load_helmchart(resource_deps, labels, chart_version = helm_chart_version)
+        load_helmchart(
+            resource_deps = resource_deps,
+            labels = labels,
+            chart_version = helm_chart_version,
+            helm_flags = helm_flags,
+        )

--- a/ingress_nginx/helm/Tiltfile
+++ b/ingress_nginx/helm/Tiltfile
@@ -1,10 +1,15 @@
 """Define the top-level `load_helmchart()` function."""
+
 load("ext://helm_resource", "helm_repo", "helm_resource")
 
 REPO_ALIAS = "ingress-nginx-repo"
 LABEL = "ingress"
 
-def load_helmchart(resource_deps = [], labels = [], chart_version = None):
+def load_helmchart(
+        resource_deps = [],
+        labels = [],
+        chart_version = None,
+        helm_flags = []):
     """
     Create a helm_resource from the ingress-nginx Helm Chart.
 
@@ -15,6 +20,7 @@ def load_helmchart(resource_deps = [], labels = [], chart_version = None):
             Default is `["ingress"]`.
         chart_version: Specify the version of the ingress-ningx Helm Chart to use.
             Default is latest.
+        helm_flags: List of strings. Custom flags passed to `helm_resource()`.
     """
     helm_repo(
         REPO_ALIAS,
@@ -22,20 +28,21 @@ def load_helmchart(resource_deps = [], labels = [], chart_version = None):
         labels = labels or [LABEL],
     )
 
-    helm_flags = [
+    default_helm_flags = [
         "--create-namespace",
         "--set=controller.allowSnippetAnnotations=true",
         "--set=controller.config.annotations-risk-level=Critical",
         "--set=controller.ingressClassResource.default=true",
     ]
+    merged_helm_flags = default_helm_flags + helm_flags
     if chart_version:
-        helm_flags.append("--version=%s" % chart_version)
+        merged_helm_flags.append("--version=%s" % chart_version)
 
     helm_resource(
         "ingress-nginx",
         chart = "%s/ingress-nginx" % REPO_ALIAS,
         namespace = "ingress-nginx",
-        flags = helm_flags,
+        flags = merged_helm_flags,
         resource_deps = [REPO_ALIAS] + resource_deps,
         labels = labels or [LABEL],
     )


### PR DESCRIPTION
This PR adds a `helm_flags` optional argument to the `ingress_nginx` function. This lets users pass their own arguments through [`helm_resource`][0] to [`helm install`][1].

Also applied some formatting using [Buildifier][2].

[0]: https://github.com/tilt-dev/tilt-extensions/tree/master/helm_resource#helm_resource
[1]: https://helm.sh/docs/helm/helm_install/
[2]: https://github.com/bazelbuild/buildtools/tree/main/buildifier#readme