### PR TITLE
Add a readiness probe to motoserver

### DIFF
--- a/motoserver/k8s/moto-statefulset.yaml
+++ b/motoserver/k8s/moto-statefulset.yaml
@@ -36,6 +36,14 @@ spec:
           mountPath: /usr/share/motoserver/
         - name: init-script
           mountPath: /motoserver/
+        readinessProbe:
+          exec:
+            command:
+            - test
+            - -f
+            - ~/is_ready
+          initialDelaySeconds: 5
+          periodSeconds: 5
       volumes:
       - name: init-script
         configMap:

--- a/motoserver/src/main.py
+++ b/motoserver/src/main.py
@@ -92,4 +92,5 @@ if __name__ == "__main__":
    
     # Initialize resources
     run_init_script()
+    (Path.home() / "is_ready").touch()
     server._thread.join()


### PR DESCRIPTION
When using the moto_sync_from_s3 extension in this repo. Doing `resource_deps = ["motoserver"]`  is not enough to guarantee that moto server has ran the init script that creates any resources that a project needs to sync to. A readiness probe will help with that. 