### PR TITLE
Datadog: Remove support for `latest` tag

### DIFF
--- a/datadog/README.md
+++ b/datadog/README.md
@@ -1,6 +1,6 @@
 # Datadog
 
-Add a button to the Tilt UI to toggle Datadog agent resources using Helm.
+Add a button to the Tilt UI to toggle [Datadog Agent](https://docs.datadoghq.com/getting_started/agent/) resources using Helm.
 
 ## Requirements
 
@@ -10,7 +10,7 @@ Add a button to the Tilt UI to toggle Datadog agent resources using Helm.
 ## Usage
 
 After registering the repo and extension (see [main README](../README.md)), you can invoke the extension using
-`datadog_up` in your Tiltfile. This will add a button to the global Tilt UI (a paw print icon) which can toggle
+`datadog_up()` in your Tiltfile. This will add a button to the global Tilt UI (a paw print icon) which can toggle
 Datadog resources on and off. Datadog API and App keys are required and can be added through the button's dropdown menu.
 
 ```starlark
@@ -19,14 +19,15 @@ load("ext://datadog", "datadog_up")
 datadog_up()
 ```
 
-If your project requires a specific version of the Datadog Agent, you can pin one using `agent_version` argument. 
-Compatible values are the `latest` tag, a major version ≥ `7`, or a semantic version ≥ `7.x.x` (default: `7`).
+If your project requires a specific version of the Datadog Agent, you can pin one using `agent_version` argument:
 
 ```starlark
+datadog_up(agent_version = "7")
+datadog_up(agent_version = "7.50")
 datadog_up(agent_version = "7.50.3")
 ```
 
-> **Note**: If multiple Tilt sessions are started, the Datadog extension will only be able to respect the arguments 
-> of a single session (likely the first place the Datadog extension is invoked). This could result in surprising and 
-> unexpected results, but would only occur in the rare circumstance that multiple Tilt sessions would be required in 
-> the first place.
+> [!IMPORTANT]
+> If multiple Tilt sessions are started, the Datadog extension will only be able to respect the arguments of a single session (likely the first place the Datadog extension is invoked).
+>
+> This could result in surprising and unexpected results, but would only occur in the rare circumstance that multiple Tilt sessions would be required in the first place.

--- a/datadog/Tiltfile
+++ b/datadog/Tiltfile
@@ -14,7 +14,6 @@ DD_KEY_FILE = os.path.join(DD_USER_CONFIG_PATH, ".keys.env")
 WORKLOAD_NAME = "datadog-agent"
 BUTTON_NAME = "de-remote:toggle-datadog-agent"
 
-DEFAULT_AGENT_TAG = "latest"
 MINIMUM_AGENT_VERSION = 7
 
 
@@ -22,14 +21,14 @@ MINIMUM_AGENT_VERSION = 7
 watch_settings(DD_USER_CONFIG_PATH)
 
 
-def datadog_up(agent_version = DEFAULT_AGENT_TAG):
+def datadog_up(agent_version = None):
     """Main function for this Tilt extension.
 
     Creates necessary resources for the Datadog Agent to run and be shared across
     multiple Tilt sessions.
 
     Args:
-      agent_version: Set a specific version tag for Datadog Agent images.
+      agent_version (`str | None`): Set a specific version tag for Datadog Agent images.
     """
     port = current_port()
     operator_port = which_sessions("uiresource", "datadog-operator")
@@ -139,9 +138,6 @@ def _datadog_keys_secret():
 
 def _validate_agent_version(agent_version):
     """Fail with errors if provided agent version tag is incompatible with extension."""
-    if agent_version == "latest":
-        return
-
     errors = []
     semverish = agent_version.split(".")
     if int(semverish[0]) < MINIMUM_AGENT_VERSION:
@@ -160,11 +156,11 @@ def _validate_agent_version(agent_version):
     all([int(i) for i in semverish])
 
 
-def _helm_resources(agent_version = DEFAULT_AGENT_TAG):
+def _helm_resources(agent_version = None):
     """Create Tilt resources required to install Datadog Agent from Helm charts.
 
     Args:
-      agent_version: Sets a specific image tag version for the Datadog Agent.
+      agent_version (`str | None`): Sets a specific image tag version for the Datadog Agent.
     """
     release_name = "datadog-agent"
     helm_repo(
@@ -175,11 +171,11 @@ def _helm_resources(agent_version = DEFAULT_AGENT_TAG):
 
     chart_values = os.path.join(EXTENSION_PATH, "values.yaml")
     flags = ["--values", chart_values]
-
-    _validate_agent_version(agent_version)
-    flags.extend(["--set", "agents.image.tag=%s" % agent_version])
-    flags.extend(["--set", "clusterAgent.image.tag=%s" % agent_version])
-    flags.extend(["--set", "clusterChecksRunner.image.tag=%s" % agent_version])
+    if agent_version != None:
+        _validate_agent_version(agent_version)
+        flags.extend(["--set", "agents.image.tag=%s" % agent_version])
+        flags.extend(["--set", "clusterAgent.image.tag=%s" % agent_version])
+        flags.extend(["--set", "clusterChecksRunner.image.tag=%s" % agent_version])
 
     helm_resource(
         WORKLOAD_NAME,

--- a/datadog/Tiltfile
+++ b/datadog/Tiltfile
@@ -14,9 +14,6 @@ DD_KEY_FILE = os.path.join(DD_USER_CONFIG_PATH, ".keys.env")
 WORKLOAD_NAME = "datadog-agent"
 BUTTON_NAME = "de-remote:toggle-datadog-agent"
 
-MINIMUM_AGENT_VERSION = 7
-
-
 # Tell Tilt not to watch/reload when configuration files update.
 watch_settings(DD_USER_CONFIG_PATH)
 
@@ -136,26 +133,6 @@ def _datadog_keys_secret():
     )
 
 
-def _validate_agent_version(agent_version):
-    """Fail with errors if provided agent version tag is incompatible with extension."""
-    errors = []
-    semverish = agent_version.split(".")
-    if int(semverish[0]) < MINIMUM_AGENT_VERSION:
-        errors.append("Datadog Extension: Agent version must be ≥ %d." % MINIMUM_AGENT_VERSION)
-
-    if len(semverish) > 3 or any(["-" in i for i in semverish]):
-        errors.append("Datadog Extension: Agent version must be in semver notation.")
-
-    for e in errors:
-        warn(e)
-
-    if errors:
-        fail("Datadog Extension: Invalid version tag '%s'; see warnings above." % agent_version)
-
-    # Last ditch effort to ensure this is a usable version number.
-    all([int(i) for i in semverish])
-
-
 def _helm_resources(agent_version = None):
     """Create Tilt resources required to install Datadog Agent from Helm charts.
 
@@ -172,7 +149,6 @@ def _helm_resources(agent_version = None):
     chart_values = os.path.join(EXTENSION_PATH, "values.yaml")
     flags = ["--values", chart_values]
     if agent_version != None:
-        _validate_agent_version(agent_version)
         flags.extend(["--set", "agents.image.tag=%s" % agent_version])
         flags.extend(["--set", "clusterAgent.image.tag=%s" % agent_version])
         flags.extend(["--set", "clusterChecksRunner.image.tag=%s" % agent_version])


### PR DESCRIPTION
Since [Datadog chart version 3.148.2](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31482), `latest` is no longer a valid identifier for agent versions (https://github.com/DataDog/helm-charts/pull/2202). 

Trying to run `datadog_up()` with no argument produces this error in Tilt:

> Error: UPGRADE FAILED: template: datadog/templates/kube-state-metrics-core-rbac.yaml:50:26: executing "datadog/templates/kube-state-metrics-core-rbac.yaml" at `<semverCompare ">=7.72.0" $imageTag>`: error calling semverCompare: invalid semantic version

While it is possible to disable these checks by scattering `doNotCheckTag: true` throughout the [`values.yaml`](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml) file, I think it makes sense to be able to rely on them to replace our own version string validation code. I checked the other repos in the DirectEmployers organization and none of them used the `agent_version` argument, so I think this change is safe.

This PR now only allows semantic version strings or `None` in the `agent_version` argument. `None` is the default and it pulls the versions specified by the chart. I also tweaked the README to be a bit nicer.

Previously: #15