### PR TITLE
pip_compile: Correct README title

### DIFF
--- a/pip_compile/README.md
+++ b/pip_compile/README.md
@@ -1,8 +1,6 @@
-# pip_compile_button
+# pip_compile
 
-Add a button to a resource to allow [pip-tools requirements](https://pip-tools.readthedocs.io/en/latest/) to be 
-compiled without relying on resources running in Kubernetes. A copy of the 
-Docker image is used to compile the requirements using `docker run`.
+Add a button to a resource to allow [pip-tools requirements](https://pip-tools.readthedocs.io/en/latest/) to be compiled without relying on resources running in Kubernetes. A copy of the Docker image is used to compile the requirements using `docker run`.
 
 ## Usage
 
@@ -11,16 +9,16 @@ After registering the repo and extension (see [main README](../README.md)), you 
 ```starlark
 load("ext://pip_compile", "pip_compile_button")
 
-pip_compile_button(    
+pip_compile_button(
     # Name of the Docker image (same as the first argument of `docker_build`).
     "image-name",
-    
+
     # Optional: Name of build stage to target (same as the `target` argument of `docker_build`).
     target = "build",
-    
+
     # Optional: Path to the directory which contains the requirements .in and .txt files (Default: `.`).
     reqs_path = "./requirements/",
-    
+
     # Optional arguments to pass to `pip-compile` (Default: `--allow-unsafe --generate-hashes`).
     compile_args = ["--upgrade-package", "black"],
 )


### PR DESCRIPTION
The README for `pip_compile` was using the same h1 text as `pip_compile_button`.

Also fixed some trailing whitespace.