### PR TITLE
datadog: Allow custom `values.yaml`, fix cluster agent deployment name

### DIFF
--- a/datadog/README.md
+++ b/datadog/README.md
@@ -11,7 +11,7 @@ Add a button to the Tilt UI to toggle [Datadog Agent](https://docs.datadoghq.com
 
 After registering the repo and extension (see [main README](../README.md)), you can invoke the extension using
 `datadog_up()` in your Tiltfile. This will add a button to the global Tilt UI (a paw print icon) which can toggle
-Datadog resources on and off. Datadog API and App keys are required and can be added through the button's dropdown menu.
+Datadog resources on and off. Datadog API and App keys are required and can be added in the dialog opened by the button.
 
 ```starlark
 load("ext://datadog", "datadog_up")
@@ -31,3 +31,9 @@ datadog_up(agent_version = "7.50.3")
 > If multiple Tilt sessions are started, the Datadog extension will only be able to respect the arguments of a single session (likely the first place the Datadog extension is invoked).
 >
 > This could result in surprising and unexpected results, but would only occur in the rare circumstance that multiple Tilt sessions would be required in the first place.
+
+To use a custom `values.yaml` file, set `values_path` to the path of the file:
+
+```starlark
+datadog_up(values_path = "k8s/values.yaml")
+```

--- a/datadog/Tiltfile
+++ b/datadog/Tiltfile
@@ -178,14 +178,14 @@ def _stub_resource():
     deploy this resource stub as a stand-in to fulfill `resource_deps` references on
     Tilt resources which rely on it.
 
-    Tails logs from the Kubernetes `datadog-cluster-agent` deployment.
+    Tails logs from the Kubernetes `datadog-agent-cluster-agent` deployment.
     """
     local_resource(
         WORKLOAD_NAME,
         serve_cmd = [
             "kubectl",
             "logs",
-            "deployment/datadog-cluster-agent",
+            "deployment/datadog-agent-cluster-agent",
             "--follow=true",
             "--ignore-errors=false",
             "--pod-running-timeout=5m",

--- a/datadog/Tiltfile
+++ b/datadog/Tiltfile
@@ -18,7 +18,7 @@ BUTTON_NAME = "de-remote:toggle-datadog-agent"
 watch_settings(DD_USER_CONFIG_PATH)
 
 
-def datadog_up(agent_version = None):
+def datadog_up(agent_version = None, values_path = None):
     """Main function for this Tilt extension.
 
     Creates necessary resources for the Datadog Agent to run and be shared across
@@ -26,6 +26,7 @@ def datadog_up(agent_version = None):
 
     Args:
       agent_version (`str | None`): Set a specific version tag for Datadog Agent images.
+      values_path (`str | None`): Path to a values.yaml file to use instead of the one from the extension.
     """
     port = current_port()
     operator_port = which_sessions("uiresource", "datadog-operator")
@@ -45,7 +46,7 @@ def datadog_up(agent_version = None):
                 + " • Get Application Key: https://app.datadoghq.com/organization-settings/application-keys"
             )
 
-        _helm_resources(agent_version)
+        _helm_resources(agent_version, values_path)
     else:
         # Stub datadog-agent resource (for resource_deps compatibility)
         _stub_resource()
@@ -133,11 +134,12 @@ def _datadog_keys_secret():
     )
 
 
-def _helm_resources(agent_version = None):
+def _helm_resources(agent_version = None, values_path = None):
     """Create Tilt resources required to install Datadog Agent from Helm charts.
 
     Args:
       agent_version (`str | None`): Sets a specific image tag version for the Datadog Agent.
+      values_path (`str | None`): Path to a values.yaml file to use instead of the one from the extension.
     """
     release_name = "datadog-agent"
     helm_repo(
@@ -146,7 +148,7 @@ def _helm_resources(agent_version = None):
         labels = ["datadog"],
     )
 
-    chart_values = os.path.join(EXTENSION_PATH, "values.yaml")
+    chart_values = values_path or os.path.join(EXTENSION_PATH, "values.yaml")
     flags = ["--values", chart_values]
     if agent_version != None:
         flags.extend(["--set", "agents.image.tag=%s" % agent_version])

--- a/datadog/scripts/variables.py
+++ b/datadog/scripts/variables.py
@@ -12,7 +12,7 @@ ENABLE_SIGNAL = "Enable"
 DISABLE_SIGNAL = "Disable"
 
 K8S_CONFIGMAP_SESSIONS = "configmap/tilt-active-sessions"
-K8S_DEPLOYMENT_DATADOG = "deployment/datadog-cluster-agent"
+K8S_DEPLOYMENT_DATADOG = "deployment/datadog-agent-cluster-agent"
 
 TILT_UIBUTTON_TOGGLE_DATADOG_AGENT = "uibutton/de-remote:toggle-datadog-agent"
 TILT_UIRESOURCE_DATADOG_AGENT = "uiresource/datadog-agent"


### PR DESCRIPTION
Makes the following changes to the `datadog` extension:

- `datadog_up()` now accepts an optional `values_path` keyword argument. This allows the user to override the `values.yaml` from this extension with their own by passing a path to theirs.
- Fixed references to `deployment/datadog-cluster-agent`, which is now `deployment/datadog-agent-cluster-agent`.